### PR TITLE
fixed CORS settings

### DIFF
--- a/lambda/questions/GET/main.go
+++ b/lambda/questions/GET/main.go
@@ -5,17 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 type Question struct {
-	QuestionID int `json:"question_id" dynamodbav:"question_id"`
-	Statement string `json:"statement" dynamodbav:"statement"`
+	QuestionID int    `json:"question_id" dynamodbav:"question_id"`
+	Statement  string `json:"statement" dynamodbav:"statement"`
 }
 
 type Response struct {
@@ -58,8 +59,8 @@ func handler(ctx context.Context, event events.APIGatewayProxyRequest) (events.A
 
 	return events.APIGatewayProxyResponse{
 		StatusCode: 200,
-		Body:		string(jsonResponse),
-		Headers:	map[string]string{"Content-Type": "application/json"},
+		Body:       string(jsonResponse),
+		Headers:    map[string]string{"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
 	}, nil
 }
 
@@ -67,11 +68,10 @@ func serverErrorResponse(err error) (events.APIGatewayProxyResponse, error) {
 	fmt.Println(err.Error())
 	return events.APIGatewayProxyResponse{
 		StatusCode: 500,
-		Body:		`{"message": "Internal Server Error"}`,
-		Headers:	map[string]string{"Content-Type": "application/json"},
+		Body:       `{"message": "Internal Server Error"}`,
+		Headers:    map[string]string{"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
 	}, nil
 }
-
 
 func main() {
 	lambda.Start(handler)

--- a/lambda/room/POST/main.go
+++ b/lambda/room/POST/main.go
@@ -51,6 +51,7 @@ func handler(ctx context.Context, event events.APIGatewayProxyRequest) (events.A
 	return events.APIGatewayProxyResponse{
 		Body:       string(responseBody),
 		StatusCode: http.StatusCreated,
+		Headers:    map[string]string{"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
 	}, nil
 }
 
@@ -62,6 +63,7 @@ func createEmptyResponseWithStatus(statuCode int) events.APIGatewayProxyResponse
 	return events.APIGatewayProxyResponse{
 		Body:       "",
 		StatusCode: statuCode,
+		Headers:    map[string]string{"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
 	}
 }
 

--- a/lib/candle-backend-stack.ts
+++ b/lib/candle-backend-stack.ts
@@ -12,6 +12,11 @@ export class CandleBackendStack extends cdk.Stack {
     // Create API Gateway
     const api = new apigateway.RestApi(this, 'CandleBackendApi', {
       restApiName: 'CandleBackendApi',
+      defaultCorsPreflightOptions: {
+        allowOrigins: apigateway.Cors.ALL_ORIGINS,
+        allowHeaders: apigateway.Cors.DEFAULT_HEADERS,
+        allowMethods: apigateway.Cors.ALL_METHODS,
+      },
     });
 
     const questionTable = new cdk.aws_dynamodb.Table(this, 'CandleBackendQuestionTable', {
@@ -58,6 +63,7 @@ export class CandleBackendStack extends cdk.Stack {
         environment: {
           TABLE_NAME: questionTable.tableName,
         },
+        
     });
     questionTable.grantReadWriteData(questionsGETHandler);
     questions.addMethod('GET', new apigateway.LambdaIntegration(questionsGETHandler));


### PR DESCRIPTION
Close https://github.com/youngeek-0410/candle-backend/issues/26 
CORS周りの設定が適切になされていなかったので直した。複雑なリクエストのときpreflight-requestを処理できるような設定を書き、Access-Controll-Allow-Origins:*を返すようにした。