### PR TITLE
update swagger result endpoints

### DIFF
--- a/docs/hacku-2023-swagger.yaml
+++ b/docs/hacku-2023-swagger.yaml
@@ -204,6 +204,13 @@ paths:
   /room/{room_id}/result:
     post:
       summary: Submit fire count for tallying
+      parameters:
+        - name: room_id
+          in: path
+          required: true
+          description: Unique identifier of the room
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -211,10 +218,14 @@ paths:
             schema:
               type: object
               required:
-                - fired_user_id
+                - user_id
+                - fire_user_id
                 - question_id
               properties:
-                fired_user_id:
+                user_id:
+                  type: string
+                  description: Unique identifier of the user
+                fire_user_id:
                   type: string
                   description: Unique identifier of the user
                 question_id:

--- a/docs/hacku-2023-swagger.yaml
+++ b/docs/hacku-2023-swagger.yaml
@@ -156,9 +156,22 @@ paths:
                         type: string
         "404":
           description: Room not found
-  /{room_id}/result:
+  /room/{room_id}/result/{user_id}:
     get:
       summary: Get final results
+      parameters:
+        - name: room_id
+          in: path
+          required: true
+          description: Unique identifier of the room
+          schema:
+            type: string
+        - name: user_id
+          in: path
+          required: true
+          description: Unique identifier of the user
+          schema:
+            type: string
       responses:
         "200":
           description: Successfully retrieved results
@@ -188,6 +201,7 @@ paths:
                               type: boolean
         "404":
           description: Results not found
+  /room/{room_id}/result:
     post:
       summary: Submit fire count for tallying
       requestBody:


### PR DESCRIPTION
## 概要
`/result` のエンドポイント二つを修正した。手元のビュワーで確認してほしい。
- `/room` のパスで始まっていなかったので修正
- GET の方に `user_id` が無いと結果を返せないためパスパラメータを追加 (これは悪手な気がするけどしかたがない)
- POST のリクエストボディに `user_id` を追加