### PR TITLE
websocketServerを追加

### DIFF
--- a/bin/candle-backend.ts
+++ b/bin/candle-backend.ts
@@ -2,6 +2,7 @@
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { CandleBackendStack } from '../lib/candle-backend-stack';
+import {CandleBackendWebSocketServerStack} from '../lib/websocket-server-stack';
 
 const app = new cdk.App();
 new CandleBackendStack(app, 'CandleBackendStack', {
@@ -22,4 +23,10 @@ new CandleBackendStack(app, 'CandleBackendStack', {
   synthesizer: new cdk.DefaultStackSynthesizer({
 		  qualifier: 'candle',
 	  }),
+});
+
+new CandleBackendWebSocketServerStack(app, 'CandleBackendWebSocketServerStack', {
+  synthesizer: new cdk.DefaultStackSynthesizer({
+      qualifier: 'candle',
+  }),
 });

--- a/lib/webSocket/Dockerfile
+++ b/lib/webSocket/Dockerfile
@@ -1,0 +1,12 @@
+# 基本イメージの選択
+FROM node:latest
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+EXPOSE 80 8000
+
+CMD ["node", "index.js"]

--- a/lib/webSocket/index.ts
+++ b/lib/webSocket/index.ts
@@ -1,0 +1,55 @@
+import {WebSocket, WebSocketServer } from 'ws';
+import * as http from 'http';
+
+interface Client {
+  ws: WebSocket;
+  topic: string;
+}
+
+const clients: Client[] = [];
+
+const wss = new WebSocketServer({ port: 80 });
+
+wss.on('connection', (ws: WebSocket) => {
+  const client: Client = { ws, topic: '' };
+  clients.push(client);
+
+  ws.on('message', (message: string) => {
+    console.log('受信メッセージ:', message.toString());
+
+    try {
+      const data = JSON.parse(message);
+
+        client.topic = data.topic;
+
+      // 同じトピックに属するクライアントにメッセージを送信
+      if (client.topic) {
+        clients.forEach((c) => {
+          if (c.topic === client.topic && c.ws !== ws && data.message) {
+            c.ws.send(data.message);
+          }
+        });
+      }
+    } catch (error) {
+      console.error('メッセージの解析に失敗:', error);
+    }
+  });
+
+  ws.on('close', () => {
+    // クライアントの接続が閉じられたらリストから削除
+    const index = clients.indexOf(client);
+    if (index !== -1) {
+      clients.splice(index, 1);
+    }
+  });
+});
+//HealthCheckでWebSocketはサポートされないので、HTTPサーバーを立てる
+const httpServer = http.createServer((req, res) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end('Healthy');
+});
+
+httpServer.listen(8000);
+console.log('WebSocketサーバーがポート80で稼働中');
+

--- a/lib/webSocket/package-lock.json
+++ b/lib/webSocket/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "websocket",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "websocket",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/ws": "^8.5.10",
+        "ws": "^8.15.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
+      "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/ws": {
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
+      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/lib/webSocket/package.json
+++ b/lib/webSocket/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "websocket",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/ws": "^8.5.10",
+    "ws": "^8.15.1"
+  }
+}

--- a/lib/websocket-server-stack.ts
+++ b/lib/websocket-server-stack.ts
@@ -1,0 +1,48 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+export class CandleBackendWebSocketServerStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        const vpc = new cdk.aws_ec2.Vpc(this, 'CandleBackendWSSVpc', {
+            maxAzs: 2,
+        });
+        const cluster = new cdk.aws_ecs.Cluster(this, 'CandleBackendWSSCluster', {
+            vpc: vpc
+        });
+        const wsImage = cdk.aws_ecs.ContainerImage.fromAsset('./lib/webSocket');
+
+        const service = new cdk.aws_ecs_patterns.ApplicationLoadBalancedFargateService(this, 'CandleBackendWSService', {
+            cluster: cluster,
+            cpu: 256,
+            desiredCount: 1,
+            taskImageOptions: {
+                image: wsImage,
+                containerPort: 80,
+            },
+            memoryLimitMiB: 512,
+            publicLoadBalancer: true,
+        });
+
+        //HTTPヘルスチェック用の設定
+        const container = service.taskDefinition.defaultContainer!;
+        container.addPortMappings({
+            containerPort: 8000,
+            hostPort: 8000,
+        });
+        
+        //デフォだとヘルスチェック数分かかってめんどい
+        service.targetGroup.configureHealthCheck({
+            interval: cdk.Duration.seconds(7),//if HTTP,must be grater than 6 by default
+            timeout: cdk.Duration.seconds(5),
+            unhealthyThresholdCount: 2,
+            healthyThresholdCount: 2,
+            path: '/',
+            port: '8000',
+        });
+
+
+        new cdk.CfnOutput(this, 'ALBDNSName', {
+            value: service.loadBalancer.loadBalancerDnsName,
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "cdk": "cdk",
     "cdk:diff": "cdk diff --all",
-    "cdk:deploy": "cdk deploy --all --require-approval never"
+    "cdk:deploy": "cdk deploy CandleBackendStack --require-approval never"
   },
   "devDependencies": {
     "@types/jest": "^29.5.8",


### PR DESCRIPTION
Close #32 
## 概要
WebSocketサーバ書いた。
`{"topic":"youngeek","message":"Hello!"}`みたいに送ると、同じトピックに接続してるクライアント全員にメッセージが送られる。
WebSocketサーバーはEC2で動いてて逐次課金されるので、スタックを分けてAPIサーバーだけデプロイできるようになっている。

## 既知だけど一旦スルーしてる問題
デプロイが終了しない。原因はコンテナのヘルスチェックが通ってないこと。対策施したがうまいこと動いてない。
ただヘルスチェック通らなくてもサーバー自体はデプロイされるし、スタック切り分けたからAPIサーバーの開発に影響しない&時間的にこれ以上付き合ってられないので一旦スルーする。あとEC2ずっと建ててると課金されるし、開発にはローカルでWSサーバー建ててもらうことになるのも1つの要因。